### PR TITLE
Force using wayland if X11 is not available

### DIFF
--- a/rest.insomnia.Insomnia.yml
+++ b/rest.insomnia.Insomnia.yml
@@ -53,11 +53,16 @@ modules:
       - type: script
         dest-filename: insomnia.sh
         commands:
+          - if [ -z "$DISPLAY" ] && [ -n "$WAYLAND_DISPLAY" ]; then
+          - EXTRA_ARGS="--enable-features=UseOzonePlatform --ozone-platform=wayland"
+          - else
+          - EXTRA_ARGS=""
+          - fi
           # Share a TMPDIR, so that multiple instance can figure out there's
           # already one running.
           - export TMPDIR="$XDG_RUNTIME_DIR/app/$FLATPAK_ID"
           # This script is required to work around a lack of SUID sandbox helper:
-          - exec zypak-wrapper /app/main/insomnia "$@"
+          - exec zypak-wrapper /app/main/insomnia $EXTRA_ARGS "$@"
       - type: file
         path: rest.insomnia.Insomnia.appdata.xml
       - type: file


### PR DESCRIPTION
If x11 is not available, force using wayland. 

Currently, if a user is not running x11 (nor xwayland), Insomnia will crash when starting. The same is true if using an override to disable x11 (`sockets=!x11`). This change force Insomnia to run under wayland on such setups. This is ideal for users who use desktop scaling, since it'll avoid rendering a blurry GUI.

For users who aren't changin any overrides, or users who are running X11 or XWayland, this has no effect. This only has an effect on setups where currently Insomnia would crash when started.