### PR TITLE
Use freedesktop platform as runtime

### DIFF
--- a/rest.insomnia.Insomnia.yml
+++ b/rest.insomnia.Insomnia.yml
@@ -1,5 +1,5 @@
 app-id: rest.insomnia.Insomnia
-runtime: org.freedesktop.Sdk
+runtime: org.freedesktop.Platform
 runtime-version: '20.08'
 sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp


### PR DESCRIPTION
Perhaps there is a good reason for it, but I see none.