### PR TITLE
Fix x-checker-data URL to match jq queries

### DIFF
--- a/rest.insomnia.Insomnia.yml
+++ b/rest.insomnia.Insomnia.yml
@@ -58,7 +58,7 @@ modules:
         sha256: eb90b982c860a54dbafe58afd3c228661838bb821f88b74cfdb318b864914e7e
         x-checker-data:
           type: json
-          url: https://api.github.com/repos/Kong/insomnia/releases/latest
+          url: https://api.github.com/repos/Kong/insomnia/releases
           version-query: map(select(.prerelease == false)) | map(select(.tag_name | startswith("core@"))) | first | .tag_name | sub("core@"; "")
           timestamp-query: map(select(.prerelease == false)) | map(select(.tag_name | startswith("core@"))) | first | .published_at
           url-query: '"https://github.com/Kong/insomnia/releases/download/core%40"


### PR DESCRIPTION
The version and timestamp JQ queries have been changed in #29 with the queries taken from from #28. However, the URL has been left unchanged which seems to be incompatible with the new queries and is [causing the CI system to fail](https://buildbot.flathub.org/#/builders/26/builds/1056).

Therefore, update the URL to match the queries (similar to the changes from #28).