### PR TITLE
feat: add support for wayland

### DIFF
--- a/rest.insomnia.Insomnia.yml
+++ b/rest.insomnia.Insomnia.yml
@@ -72,6 +72,6 @@ modules:
           # already one running.
           - export TMPDIR="$XDG_RUNTIME_DIR/app/$FLATPAK_ID"
           # This script is required to work around a lack of SUID sandbox helper:
-          - exec zypak-wrapper /app/main/insomnia "$@"
+          - exec zypak-wrapper /app/main/insomnia --ozone-platform-hint=auto "$@"
       - type: file
         path: rest.insomnia.Insomnia.appdata.xml


### PR DESCRIPTION
Enable chromium's built-in wayland support, with fallback to X11.

https://chromium.googlesource.com/chromium/src/+/HEAD/docs/ozone_overview.md#linux-desktop-x11-waterfall