### PR TITLE
fix: upgrade runtime & base version …

### DIFF
--- a/rest.insomnia.Insomnia.yml
+++ b/rest.insomnia.Insomnia.yml
@@ -12,6 +12,7 @@ finish-args:
   - --socket=x11
   - --socket=wayland
   - --share=network
+  - --device=dri
 modules:
   - name: unappimage
     buildsystem: simple

--- a/rest.insomnia.Insomnia.yml
+++ b/rest.insomnia.Insomnia.yml
@@ -1,9 +1,9 @@
 app-id: rest.insomnia.Insomnia
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
-base-version: '21.08'
+base-version: '22.08'
 separate-locales: false
 command: insomnia
 rename-icon: insomnia
@@ -12,9 +12,6 @@ finish-args:
   - --socket=x11
   - --socket=wayland
   - --share=network
-  # I'm not a fan of this permission, but for some reason Insomnia won't start
-  # without it. Contributions welcome:
-  - --device=all
 modules:
   - name: unappimage
     buildsystem: simple


### PR DESCRIPTION
…to be compatible with recent insomnia release

The latest insomnia release is no longer compatible with runtime version 21.08. So this commit upgrades it. Also removes unused permission `--device=all`

Closes #57