### PR TITLE
Add missing launchable tag

### DIFF
--- a/rest.insomnia.Insomnia.appdata.xml
+++ b/rest.insomnia.Insomnia.appdata.xml
@@ -8,6 +8,7 @@
   <metadata_license>CC0-1.0</metadata_license>
   <url type="homepage">https://insomnia.rest/</url>
   <url type="bugtracker">https://github.com/flathub/rest.insomnia.Insomnia/issues</url>
+  <launchable type="desktop-id">rest.insomnia.Insomnia.desktop</launchable>
   <description>
     <!-- Copy pasted from the website -->
     <p>


### PR DESCRIPTION
Fixes the "desktop-app-launchable-missing" appstream failing validation ocurring during the "Validate build" step from buildbot. Example of failing build: https://buildbot.flathub.org/#/builders/37/builds/15091.

see also:
https://www.freedesktop.org/software/appstream/docs/chap-Validation.html#asv-desktop-app-launchable-missing
https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-launchable
